### PR TITLE
Optimize self-signed certificate logic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,4 +176,31 @@ jobs:
             rstun-linux-aarch64.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+  linux-musl-aarch64:
+    name: Linux musl Aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-musl
+          override: true
+      - run: sudo apt-get -y install musl-tools && rustup target add aarch64-unknown-linux-musl
+      - run: cargo install cross --git https://github.com/cross-rs/cross
+      - run: cross build --all-features --release --target aarch64-unknown-linux-musl
+      - run: mkdir -p rstun-linux-musl-aarch64
+      - run: mv target/aarch64-unknown-linux-musl/release/rstunc ./rstun-linux-musl-aarch64/
+      - run: mv target/aarch64-unknown-linux-musl/release/rstund ./rstun-linux-musl-aarch64/
+      - run: tar zcf rstun-linux-musl-aarch64.tar.gz ./rstun-linux-musl-aarch64/*
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            rstun-linux-musl-aarch64.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -570,38 +570,32 @@ impl Client {
             return Ok((client_config, "localhost".to_string()));
         }
 
+        //when client config provides a certificate
         let certs = pem_util::load_certificates_from_pem(self.config.cert_path.as_str())
             .context("failed to read from cert file")?;
-        let cert = certs
-            .first()
-            .context("certificate is not in PEM format")?
-            .clone();
-
+        if certs.is_empty() {
+            bail!("No certificates found in provided file: {}", self.config.cert_path);
+        }
         let mut roots = RootCertStore::empty();
-        roots.add(cert).context(format!(
-            "failed to add certificate: {}",
-            self.config.cert_path
-        ))?;
-
-        let (_rem, cert) = X509Certificate::from_der(certs.first().unwrap().as_ref()).context(
-            format!("not a valid X509Certificate: {}", self.config.cert_path),
-        )?;
-
-        let common_name = cert
-            .subject()
-            .iter_common_name()
-            .next()
-            .and_then(|cn| cn.as_str().ok())
-            .context(format!(
-                "failed to read CN (Common Name) from specified certificate: {}",
+		//save all certificates in the certificate chain to the trust list
+        for cert in &certs {
+            roots.add(cert.clone()).context(format!(
+                "failed to add certificate from file: {}",
                 self.config.cert_path
             ))?;
+        }
+
+		//for self-signed certificates, generating IP-based TLS certificates is not difficult
+		let domain_or_ip = match self.config.server_addr.rfind(':') {
+			Some(colon_index) => self.config.server_addr[0..colon_index].to_string(),
+			None => self.config.server_addr.to_string(),
+		};
 
         Ok((
             self.create_client_config_builder(&cipher)?
                 .with_root_certificates(roots)
                 .with_no_client_auth(),
-            common_name.to_string(),
+            domain_or_ip,
         ))
     }
 


### PR DESCRIPTION
Update client.rs

1.Support certificate chain(root_ca->mid_ca->edge_ca->cert) on client;

2.When the client provides a self-signed certificate, use domain or ip from server address(instead of common name from certificate)  as sni to connect quic : 
①The previous implementation did not support wildcard certificates(for example , CN = *.domain.com)
②It is very easy to support ip certificates in self-signed certificates);

