### PR TITLE
support multiple tcp tunnels and multiple udp tunnels in rstunc

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,10 +1,5 @@
 use crate::{
-    pem_util, socket_addr_with_unspecified_ip_port,
-    tcp::tcp_tunnel::TcpTunnel,
-    tunnel_info_bridge::{TunnelInfo, TunnelInfoBridge, TunnelInfoType, TunnelTraffic},
-    udp::{udp_server::UdpServer, udp_tunnel::UdpTunnel},
-    ClientConfig, LoginInfo, SelectedCipherSuite, TcpServer, TunnelMessage, TUNNEL_MODE_IN,
-    TUNNEL_MODE_OUT,
+    pem_util, socket_addr_with_unspecified_ip_port, tcp::tcp_tunnel::TcpTunnel, tunnel_info_bridge::{TunnelInfo, TunnelInfoBridge, TunnelInfoType, TunnelTraffic}, udp::{udp_server::UdpServer, udp_tunnel::UdpTunnel}, ClientConfig, LoginInfo, SelectedCipherSuite, ServerType, TcpServer, TunnelMessage, TUNNEL_MODE_IN, TUNNEL_MODE_OUT
 };
 use anyhow::{bail, Context, Result};
 use backon::ExponentialBuilder;
@@ -13,10 +8,7 @@ use log::{error, info, warn};
 use quinn::{congestion, crypto::rustls::QuicClientConfig, Connection, Endpoint, TransportConfig};
 use quinn_proto::{IdleTimeout, VarInt};
 use rs_utilities::log_and_bail;
-use rs_utilities::{
-    dns::{self, DNSQueryOrdering, DNSResolverConfig, DNSResolverLookupIpStrategy},
-    unwrap_or_return,
-};
+use rs_utilities::dns::{self, DNSQueryOrdering, DNSResolverConfig, DNSResolverLookupIpStrategy};
 use rustls::{
     client::danger::ServerCertVerified,
     crypto::{ring::cipher_suite, CryptoProvider},
@@ -135,61 +127,80 @@ impl Client {
             .block_on(async { self.connect_and_serve().await });
     }
 
-    pub async fn start_tcp_server(&self) -> Result<Option<SocketAddr>> {
+    pub async fn start_tcp_server(&self) -> Result<Vec<SocketAddr>> {
         if self.config.mode != TUNNEL_MODE_OUT {
             bail!("call start_tcp_server() for TunnelOut mode only");
         }
-        let addr = unwrap_or_return!(self.config.local_tcp_server_addr, Ok(None));
-
-        self.post_tunnel_log("preparing tcp server...");
-
-        let bind_tcp_server = || async { TcpServer::bind_and_start(addr).await };
-        let tcp_server = bind_tcp_server
-            .retry(
-                ExponentialBuilder::default()
-                    .with_max_delay(Duration::from_secs(10))
-                    .with_max_times(10),
-            )
-            .sleep(tokio::time::sleep)
-            .notify(|err: &anyhow::Error, dur: Duration| {
-                warn!("will retry after {dur:?}, err: {err:?}");
-            })
-            .await?;
-
-        let addr = tcp_server.addr();
-        self.post_tunnel_log(format!("[TunnelOut] tcp server bound to: {addr}").as_str());
-
-        let mut state = self.inner_state.lock().unwrap();
-        state.tcp_server = Some(tcp_server);
-        Ok(Some(addr))
+    
+        let mut addrs = Vec::new();
+    
+        for tunnel in &self.config.tunnels {
+            if tunnel.server_type == ServerType::Tcp && tunnel.mode == TUNNEL_MODE_OUT {
+                if let Some(addr) = tunnel.local_server_addr {
+                    self.post_tunnel_log("preparing tcp server...");
+    
+                    let bind_tcp_server = || async { TcpServer::bind_and_start(addr).await };
+                    let tcp_server = bind_tcp_server
+                        .retry(
+                            ExponentialBuilder::default()
+                                .with_max_delay(Duration::from_secs(10))
+                                .with_max_times(10),
+                        )
+                        .sleep(tokio::time::sleep)
+                        .notify(|err: &anyhow::Error, dur: Duration| {
+                            warn!("will retry after {dur:?}, err: {err:?}");
+                        })
+                        .await?;
+    
+                    let addr = tcp_server.addr();
+                    self.post_tunnel_log(format!("[TunnelOut] tcp server bound to: {addr}").as_str());
+    
+                    let mut state = self.inner_state.lock().unwrap();
+                    state.tcp_server = Some(tcp_server);
+                    addrs.push(addr);
+                }
+            }
+        }
+    
+        Ok(addrs)
     }
 
-    pub async fn start_udp_server(&self) -> Result<Option<SocketAddr>> {
+    pub async fn start_udp_server(&self) -> Result<Vec<SocketAddr>> {
         if self.config.mode != TUNNEL_MODE_OUT {
             bail!("call start_udp_server() for TunnelOut mode only");
         }
-        let addr = unwrap_or_return!(self.config.local_udp_server_addr, Ok(None));
-        self.post_tunnel_log("preparing udp server...");
-
-        // create a local udp server for 'OUT' tunnel
-        let bind_udp_server = || async { UdpServer::bind_and_start(addr).await };
-        let udp_server = bind_udp_server
-            .retry(
-                ExponentialBuilder::default()
-                    .with_max_delay(Duration::from_secs(10))
-                    .with_max_times(10),
-            )
-            .sleep(tokio::time::sleep)
-            .notify(|err: &anyhow::Error, dur: Duration| {
-                warn!("will retry after {dur:?}, err: {err:?}");
-            })
-            .await?;
-        let addr = udp_server.addr();
-
-        self.post_tunnel_log(format!("[TunnelOut] udp server bound to: {addr}").as_str());
-
-        inner_state!(self, udp_server) = Some(udp_server);
-        Ok(Some(addr))
+    
+        let mut addrs = Vec::new();
+    
+        for tunnel in &self.config.tunnels {
+            if tunnel.server_type == ServerType::Udp && tunnel.mode == TUNNEL_MODE_OUT {
+                if let Some(addr) = tunnel.local_server_addr {
+                    self.post_tunnel_log("preparing udp server...");
+    
+                    let bind_udp_server = || async { UdpServer::bind_and_start(addr).await };
+                    let udp_server = bind_udp_server
+                        .retry(
+                            ExponentialBuilder::default()
+                                .with_max_delay(Duration::from_secs(10))
+                                .with_max_times(10),
+                        )
+                        .sleep(tokio::time::sleep)
+                        .notify(|err: &anyhow::Error, dur: Duration| {
+                            warn!("will retry after {dur:?}, err: {err:?}");
+                        })
+                        .await?;
+    
+                    let addr = udp_server.addr();
+                    self.post_tunnel_log(format!("[TunnelOut] udp server bound to: {addr}").as_str());
+    
+                    let mut state = self.inner_state.lock().unwrap();
+                    state.udp_server = Some(udp_server);
+                    addrs.push(addr);
+                }
+            }
+        }
+    
+        Ok(addrs)
     }
 
     pub fn get_config(&self) -> ClientConfig {
@@ -298,39 +309,35 @@ impl Client {
         let mut endpoint = quinn::Endpoint::client(local_addr)?;
         endpoint.set_default_client_config(quinn_client_cfg);
 
-        let is_tunnel_in = self.config.mode == TUNNEL_MODE_IN;
-        if let Some(tcp_upstream) = &self.config.tcp_upstream {
+        for tunnel in &self.config.tunnels {
             let login_info = LoginInfo {
                 password: self.config.password.clone(),
-                upstream: tcp_upstream.clone(),
+                upstream: tunnel.upstream.clone().unwrap(),
             };
-            let login_msg = if is_tunnel_in {
-                TunnelMessage::ReqTcpInLogin(login_info)
-            } else {
-                TunnelMessage::ReqTcpOutLogin(login_info)
+            let login_msg = match tunnel.server_type {
+                ServerType::Tcp => {
+                    if tunnel.mode == TUNNEL_MODE_IN {
+                        TunnelMessage::ReqTcpInLogin(login_info)
+                    } else {
+                        TunnelMessage::ReqTcpOutLogin(login_info)
+                    }
+                }
+                ServerType::Udp => {
+                    if tunnel.mode == TUNNEL_MODE_IN {
+                        TunnelMessage::ReqUdpInLogin(login_info)
+                    } else {
+                        TunnelMessage::ReqUdpOutLogin(login_info)
+                    }
+                }
             };
-
+    
             let conn = self
                 .login(&endpoint, &remote_addr, domain.as_str(), login_msg)
                 .await?;
-            inner_state!(self, tcp_conn) = Some(conn);
-        }
-
-        if let Some(udp_upstream) = &self.config.udp_upstream {
-            let login_info = LoginInfo {
-                password: self.config.password.clone(),
-                upstream: udp_upstream.clone(),
-            };
-            let login_msg = if is_tunnel_in {
-                TunnelMessage::ReqUdpInLogin(login_info)
-            } else {
-                TunnelMessage::ReqUdpOutLogin(login_info)
-            };
-
-            let conn = self
-                .login(&endpoint, &remote_addr, domain.as_str(), login_msg)
-                .await?;
-            inner_state!(self, udp_conn) = Some(conn);
+            match tunnel.server_type {
+                ServerType::Tcp => inner_state!(self, tcp_conn) = Some(conn),
+                ServerType::Udp => inner_state!(self, udp_conn) = Some(conn),
+            }
         }
 
         self.set_and_post_tunnel_state(ClientState::Tunneling);
@@ -380,19 +387,19 @@ impl Client {
 
     async fn serve_outgoing(&mut self, pending_tcp_stream: &mut Option<TcpStream>) -> Result<()> {
         self.set_and_post_tunnel_state(ClientState::Preparing);
-
-        if self.config.local_tcp_server_addr.is_some() && inner_state!(self, tcp_server).is_none() {
+    
+        if self.config.tunnels.iter().any(|tunnel| tunnel.server_type == ServerType::Tcp && tunnel.mode == TUNNEL_MODE_OUT && tunnel.local_server_addr.is_some()) && inner_state!(self, tcp_server).is_none() {
             self.start_tcp_server().await?;
             let conn = inner_state!(self, tcp_conn).clone().unwrap();
             self.report_traffic_data_in_background(conn).await;
         }
-
-        if self.config.local_udp_server_addr.is_some() && inner_state!(self, udp_server).is_none() {
+    
+        if self.config.tunnels.iter().any(|tunnel| tunnel.server_type == ServerType::Udp && tunnel.mode == TUNNEL_MODE_OUT && tunnel.local_server_addr.is_some()) && inner_state!(self, udp_server).is_none() {
             self.start_udp_server().await?;
             let conn = inner_state!(self, udp_conn).clone().unwrap();
             self.report_traffic_data_in_background(conn.clone()).await;
         }
-
+    
         let (tcp_server, tcp_sender) = {
             if let Some(tcp_server) = &self.inner_state.lock().unwrap().tcp_server {
                 (
@@ -403,13 +410,13 @@ impl Client {
                 (None, None)
             }
         };
-
+    
         self.set_and_post_tunnel_state(ClientState::Tunneling);
-
+    
         let udp_server = inner_state!(self, udp_server).clone();
         if let Some(udp_server) = udp_server {
             let conn = inner_state!(self, udp_conn).clone().unwrap();
-            let udp_only = self.config.local_tcp_server_addr.is_none();
+            let udp_only = self.config.tunnels.iter().all(|tunnel| tunnel.server_type != ServerType::Tcp);
             let udp_timeout_ms = self.config.udp_timeout_ms;
             self.post_tunnel_log(
                 format!(
@@ -422,7 +429,7 @@ impl Client {
                 .await
                 .ok();
         }
-
+    
         if let Some(mut tcp_server) = tcp_server {
             let conn = inner_state!(self, tcp_conn).take().unwrap();
             self.post_tunnel_log(
@@ -440,11 +447,11 @@ impl Client {
                 self.config.tcp_timeout_ms,
             )
             .await;
-
+    
             let mut state = self.inner_state.lock().unwrap();
             state.tcp_conn = Some(conn);
         }
-
+    
         let mut inner_state = self.inner_state.lock().unwrap();
         if let Some(tcp_conn) = &inner_state.tcp_conn {
             let stats = tcp_conn.stats();
@@ -459,25 +466,30 @@ impl Client {
 
     async fn serve_incoming(&self) -> Result<()> {
         self.post_tunnel_log("start serving in [TunnelIn] mode...");
-
-        if let Some(udp_server_addr) = self.config.local_udp_server_addr {
-            let conn = inner_state!(self, udp_conn).clone().unwrap();
-            let udp_only = self.config.local_tcp_server_addr.is_none();
-            let udp_timeout_ms = self.config.udp_timeout_ms;
-            if udp_only {
-                UdpTunnel::process(conn, udp_server_addr, udp_timeout_ms).await;
-            } else {
-                tokio::spawn(async move {
-                    UdpTunnel::process(conn, udp_server_addr, udp_timeout_ms).await;
-                });
+    
+        for tunnel in &self.config.tunnels {
+            if tunnel.mode == TUNNEL_MODE_IN {
+                match tunnel.server_type {
+                    ServerType::Tcp => {
+                        if let Some(addr) = tunnel.local_server_addr {
+                            let conn = inner_state!(self, tcp_conn).clone().unwrap();
+                            let tcp_timeout_ms = self.config.tcp_timeout_ms;
+                            TcpTunnel::process(conn, addr, tcp_timeout_ms).await;
+                        }
+                    }
+                    ServerType::Udp => {
+                        if let Some(addr) = tunnel.local_server_addr {
+                            let conn = inner_state!(self, udp_conn).clone().unwrap();
+                            let udp_timeout_ms = self.config.udp_timeout_ms;
+                            tokio::spawn(async move {
+                                UdpTunnel::process(conn, addr, udp_timeout_ms).await;
+                            });
+                        }
+                    }
+                }
             }
         }
-
-        if let Some(addr) = self.config.local_tcp_server_addr {
-            let conn = inner_state!(self, tcp_conn).clone().unwrap();
-            let tcp_timeout_ms = self.config.tcp_timeout_ms;
-            TcpTunnel::process(conn, addr, tcp_timeout_ms).await;
-        }
+    
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,10 +154,22 @@ pub enum TunnelType {
     UdpIn(UdpTunnelInInfo),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ServerType {
+    Tcp,
+    Udp,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TunnelConfig {
+    pub server_type: ServerType,
+    pub local_server_addr: Option<SocketAddr>,
+    pub upstream: Option<Upstream>,
+    pub mode: String,
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct ClientConfig {
-    pub local_tcp_server_addr: Option<SocketAddr>,
-    pub local_udp_server_addr: Option<SocketAddr>,
     pub cert_path: String,
     pub cipher: String,
     pub server_addr: String,
@@ -166,8 +178,7 @@ pub struct ClientConfig {
     pub quic_timeout_ms: u64,
     pub tcp_timeout_ms: u64,
     pub udp_timeout_ms: u64,
-    pub tcp_upstream: Option<Upstream>,
-    pub udp_upstream: Option<Upstream>,
+    pub tunnels: Vec<TunnelConfig>,
     pub dot_servers: Vec<String>,
     pub dns_servers: Vec<String>,
     pub workers: usize,
@@ -214,9 +225,12 @@ impl ClientConfig {
         if tcp_addr_mapping.is_empty() && udp_addr_mapping.is_empty() {
             log_and_bail!("must specify either --tcp-mapping or --udp-mapping, or both");
         }
+        if mode != "IN" && mode != "OUT" {
+            log_and_bail!("invalid mode: {} , mode can only be IN or OUT",mode);
+        }
+        let tcp_sock_mappings = parse_addr_mappings(UpstreamType::Tcp, tcp_addr_mapping, mode)?;
+        let udp_sock_mappings = parse_addr_mappings(UpstreamType::Udp, udp_addr_mapping, mode)?;
 
-        let tcp_sock_mapping = parse_addr_mapping(UpstreamType::Tcp, tcp_addr_mapping)?;
-        let udp_sock_mapping = parse_addr_mapping(UpstreamType::Udp, udp_addr_mapping)?;
         if quic_timeout_ms == 0 {
             quic_timeout_ms = 30000;
         }
@@ -245,84 +259,80 @@ impl ClientConfig {
         config.quic_timeout_ms = quic_timeout_ms;
         config.tcp_timeout_ms = tcp_timeout_ms;
         config.udp_timeout_ms = udp_timeout_ms;
-        config.tcp_upstream = parse_as_upstream(mode, &tcp_sock_mapping)?;
-        config.udp_upstream = parse_as_upstream(mode, &udp_sock_mapping)?;
         config.dot_servers = dot.split(',').map(|s| s.to_string()).collect();
         config.dns_servers = dns.split(',').map(|s| s.to_string()).collect();
         config.mode = if mode == TUNNEL_MODE_IN {
-            config.local_tcp_server_addr = *tcp_sock_mapping.get(1).unwrap_or(&None);
-            config.local_udp_server_addr = *udp_sock_mapping.get(1).unwrap_or(&None);
-
             TUNNEL_MODE_IN
         } else {
-            config.local_tcp_server_addr = *tcp_sock_mapping.first().unwrap_or(&None);
-            config.local_udp_server_addr = *udp_sock_mapping.first().unwrap_or(&None);
-
             TUNNEL_MODE_OUT
         };
+        for (local_addr, upstream, mode) in tcp_sock_mappings {
+            config.tunnels.push(TunnelConfig {
+                server_type: ServerType::Tcp,
+                local_server_addr: local_addr,
+                upstream,
+                mode,
+            });
+        }
+
+        for (local_addr, upstream, mode) in udp_sock_mappings {
+            config.tunnels.push(TunnelConfig {
+                server_type: ServerType::Udp,
+                local_server_addr: local_addr,
+                upstream,
+                mode,
+            });
+        }
 
         Ok(config)
     }
 }
 
-fn parse_as_upstream(mode: &str, sock_mapping: &[Option<SocketAddr>]) -> Result<Option<Upstream>> {
-    if sock_mapping.is_empty() {
-        Ok(None)
-    } else {
-        if sock_mapping[0].is_none() {
-            bail!("'ANY' is not allowed as local server");
-        }
-
-        let upstream_addr = if mode == TUNNEL_MODE_OUT {
-            sock_mapping[1]
-        } else {
-            if sock_mapping[1].is_none() {
-                bail!("'ANY' is not allowed as remote server for IN mode tunneling");
-            }
-            sock_mapping[0]
-        };
-
-        Ok(match upstream_addr {
-            None => Some(Upstream::PeerDefault),
-            Some(addr) => Some(Upstream::ClientSpecified(addr)),
-        })
-    }
-}
-
-fn parse_addr_mapping(
+fn parse_addr_mappings(
     upstream_type: UpstreamType,
     mapping: &str,
-) -> Result<Vec<Option<SocketAddr>>> {
+    default_mode: &str,
+) -> Result<Vec<(Option<SocketAddr>, Option<Upstream>, String)>> {
     if mapping.is_empty() {
         return Ok(vec![]);
     }
 
-    let addr_mapping: Vec<&str> = mapping.split('^').collect();
-    if addr_mapping.len() != 2 {
-        log_and_bail!("invalid {upstream_type} address mapping: {mapping}");
-    }
-
-    let mut sock_addrs: Vec<Option<SocketAddr>> = Vec::with_capacity(addr_mapping.len());
-    for addr in &addr_mapping {
-        if *addr == "ANY" {
-            sock_addrs.push(None);
-        } else {
-            match addr.parse::<SocketAddr>() {
-                Ok(sock_addr) => {
-                    sock_addrs.push(Some(sock_addr));
+    let mut result = Vec::new();
+    for mapping in mapping.split(',') {
+        let parts: Vec<&str> = mapping.split('^').collect();
+        let (mode, local_addr, upstream_addr) = match parts.len() {
+            2 => (default_mode, parts[0], parts[1]),
+            3 => {
+                if parts[0] != "IN" && parts[0] != "OUT" {
+                    log_and_bail!("invalid mode: {} in address mapping: {}",parts[0], mapping);
                 }
-                Err(_) => {
-                    // assumes addr is a port
-                    let addr = format!("127.0.0.1:{addr}");
-                    sock_addrs.push(Some(
-                        addr.parse::<SocketAddr>()
-                            .context(format!("invalid address mapping: [{mapping}]"))?,
-                    ));
-                }
+                (parts[0], parts[1], parts[2])
             }
-        }
+            _ => {
+                log_and_bail!("invalid {} address mapping: {}",upstream_type, mapping);
+            }
+        };
+
+        let local_addr = if local_addr == "ANY" {
+            None
+        } else {
+            Some(local_addr.parse::<SocketAddr>().context(format!("invalid local address: [{local_addr}] in mapping: [{mapping}]"))?)
+        };
+
+        let upstream = if upstream_addr == "ANY" {
+            Some(Upstream::PeerDefault)
+        } else {
+            let upstream_addr = if upstream_addr.parse::<u16>().is_ok() {
+                format!("127.0.0.1:{}", upstream_addr)
+            } else {
+                upstream_addr.to_string()
+            };
+            Some(Upstream::ClientSpecified(upstream_addr.parse::<SocketAddr>().context(format!("invalid upstream address: [{upstream_addr}] in mapping: [{mapping}]"))?))
+        };
+
+        result.push((local_addr, upstream, mode.to_string()));
     }
-    Ok(sock_addrs)
+    Ok(result)
 }
 
 pub fn socket_addr_with_unspecified_ip_port(ipv6: bool) -> SocketAddr {


### PR DESCRIPTION
★support multiple tcp tunnels and multiple udp tunnels in rstunc via multiple quic channels

**command example:**
```
rstunc
  --mode OUT \
  --server-addr 1.2.3.4:6060 \
  --password 123456 \
  --cert path/to/cert.der \
  --tcp-mapping IN^0.0.0.0:2900^2800,OUT^0.0.0.0:4900^4800,0.0.0.0:6900^6800 \
  --udp-mapping IN^0.0.0.0:1900^1800,OUT^0.0.0.0:3900^3800,0.0.0.0:5900^5800 \
  --loglevel D
```

**special note:** 
For compatibility reasons, I do not deleted the parameter of mode  to ensure that the original command can be executed successfully.
