### PR TITLE
Add optional `--hop-interval-ms` to counter ISP UDP QoS

### DIFF
--- a/src/bin/rstunc.rs
+++ b/src/bin/rstunc.rs
@@ -23,6 +23,7 @@ fn main() {
         args.quic_timeout_ms,
         args.tcp_timeout_ms,
         args.udp_timeout_ms,
+        args.hop_interval_ms,
     )
     .map_err(|e| {
         error!("{e}");
@@ -93,6 +94,10 @@ struct RstuncArgs {
     /// UDP idle timeout in milliseconds
     #[arg(long, default_value_t = 5000)]
     udp_timeout_ms: u64,
+
+    /// Hop interval in milliseconds. Disabled by default (0 means disabled)
+    #[arg(long, default_value_t = 0)]
+    hop_interval_ms: u64,
 
     /// Comma-separated DoT servers (domains) for DNS resolution, e.g. "dns.google,one.one.one.one". Takes precedence over --dns if set.
     #[arg(long, verbatim_doc_comment, default_value = "")]

--- a/src/client.rs
+++ b/src/client.rs
@@ -299,7 +299,7 @@ impl Client {
                         loop {
                             interval.tick().await;
 
-                            // 创建新的 UDP socket
+                            // create new UDP socket
                             let new_socket = match tokio::net::UdpSocket::bind(SocketAddr::new(
                                 if remote_addr.is_ipv6() {
                                     IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED)
@@ -317,7 +317,7 @@ impl Client {
                                 }
                             };
 
-                            // 将 Tokio UdpSocket 转换为 std::net::UdpSocket
+                            // transform Tokio UdpSocket to std::net::UdpSocket
                             let std_socket = match new_socket.into_std() {
                                 Ok(std_socket) => std_socket,
                                 Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ pub struct ClientConfig {
     pub quic_timeout_ms: u64,
     pub tcp_timeout_ms: u64,
     pub udp_timeout_ms: u64,
+    pub hop_interval_ms: u64,
     pub tunnels: Vec<TunnelConfig>,
     pub dot_servers: Vec<String>,
     pub dns_servers: Vec<String>,
@@ -238,6 +239,7 @@ impl ClientConfig {
         mut quic_timeout_ms: u64,
         mut tcp_timeout_ms: u64,
         mut udp_timeout_ms: u64,
+        mut hop_interval_ms: u64,
     ) -> Result<ClientConfig> {
         if tcp_addr_mappings.is_empty() && udp_addr_mappings.is_empty() {
             log_and_bail!("must specify either --tcp-mappings or --udp-mappings, or both");
@@ -251,6 +253,11 @@ impl ClientConfig {
         }
         if udp_timeout_ms == 0 {
             udp_timeout_ms = 5000;
+        }
+        if hop_interval_ms <= 0 {
+            hop_interval_ms = 0;
+        } else if hop_interval_ms < 30000 {
+            hop_interval_ms = 30000;
         }
 
         let mut config = ClientConfig {
@@ -271,6 +278,7 @@ impl ClientConfig {
             quic_timeout_ms,
             tcp_timeout_ms,
             udp_timeout_ms,
+            hop_interval_ms,
             dot_servers: dot.split(',').map(|s| s.to_string()).collect(),
             dns_servers: dns.split(',').map(|s| s.to_string()).collect(),
             ..ClientConfig::default()


### PR DESCRIPTION
When set > 0, the QUIC connection
will automatically switch UDP connections periodically to mitigate QoS throttling (common in some regions).

Minimum enforced value: 30000 ms.
Values <= 0 disable the feature (default: 0).



**Additional Note**: 
In some regions, ISPs severely throttle UDP peer-to-peer connections that maintain prolonged communication, resulting in reduced network transfer speeds. 

This issue can be easily resolved by reconnecting to the server using a different port. 

Fortunately, the QUIC protocol supports connection migration, which enables seamless transfer of QUIC to a new UDP connection without re-handshaking or renegotiation. 

This commit implements periodic migration of QUIC to new UDP connections to address QoS issues.