### PR TITLE
feat(client): Add connection migration feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Rust
 on:
   push:
     tags:
-      - 'release/*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   linux-x86_64:

--- a/src/bin/rstunc.rs
+++ b/src/bin/rstunc.rs
@@ -23,6 +23,7 @@ fn main() {
         args.quic_timeout_ms,
         args.tcp_timeout_ms,
         args.udp_timeout_ms,
+        args.hop_interval_ms,
     )
     .map_err(|e| {
         error!("{e}");
@@ -93,6 +94,9 @@ struct RstuncArgs {
     /// UDP idle timeout in milliseconds
     #[arg(long, default_value_t = 5000)]
     udp_timeout_ms: u64,
+
+    #[arg(long, default_value_t = 0)]
+    hop_interval_ms: u64,
 
     /// Comma-separated DoT servers (domains) for DNS resolution, e.g. "dns.google,one.one.one.one". Takes precedence over --dns if set.
     #[arg(long, verbatim_doc_comment, default_value = "")]


### PR DESCRIPTION
- Add `migration_handles` and `migration_stop_senders` maps to the `State` struct
- Implement `start_connection_migration_task` and `stop_connection_migration_task` methods
- Start the connection migration task after the connection is established, and stop it when the connection is closed
- Add `perform_connection_migration` method to implement the actual migration logic
- Add `hop_interval_seconds` field to `ClientConfig` to control the migration interval